### PR TITLE
Allow equirectangular image as scene background

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1184,7 +1184,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		if ( background && background.isCubeTexture ) {
+		if ( background && ( background.isCubeTexture || background.isRenderTargetCubeTexture ) ) {
 
 			backgroundCamera2.projectionMatrix.copy( camera.projectionMatrix );
 

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -1,5 +1,11 @@
 import { Texture } from './Texture';
 import { CubeReflectionMapping } from '../constants';
+import { Scene } from '../scenes/Scene';
+import { CubeCamera } from '../cameras/CubeCamera'
+import { MeshBasicMaterial } from '../materials/MeshBasicMaterial'
+import { BackSide, RepeatWrapping } from '../constants'
+import { Mesh } from '../objects/Mesh'
+import { SphereBufferGeometry } from '../geometries/SphereBufferGeometry'
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -37,5 +43,34 @@ Object.defineProperty( CubeTexture.prototype, 'images', {
 
 } );
 
+CubeTexture.prototype.fromEquirectangular = function( renderer, source, size, detail ) {
+
+	var scene = new Scene();
+
+	var gl = renderer.getContext();
+	var maxSize = gl.getParameter( gl.MAX_CUBE_MAP_TEXTURE_SIZE )
+
+	var camera = new CubeCamera( 1, 100000, Math.min( size, maxSize ) );
+
+	source.wrapS = source.wrapT = RepeatWrapping;
+
+	var material = new MeshBasicMaterial( {
+		map: source,
+		side: BackSide
+	} );
+
+	var mesh = new Mesh(
+		new SphereBufferGeometry( 100, 10 * ( detail || 3 ), 10 * ( detail || 3 ) ),
+		material
+	);
+
+	scene.add( mesh );
+
+	camera.updateCubeMap( renderer, scene );
+	camera.renderTarget.texture.isRenderTargetCubeTexture = true;
+
+	return camera.renderTarget.texture;
+
+}
 
 export { CubeTexture };


### PR DESCRIPTION
`fromEquirectangular()` method added to `CubeTexture` object, and flag added in renderer which allows equirectangular images to be set as the scene background.