### PR TITLE
Constant Scroll Speed

### DIFF
--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -167,7 +167,7 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		// if ( scope.enabled === false ) return;
 
-		scope.zoom( new THREE.Vector3( 0, 0, event.deltaY ) );
+		scope.zoom( new THREE.Vector3( 0, 0, Math.sign( event.deltaY ) * 50 ) );
 
 	}
 


### PR DESCRIPTION
Since the deltaY value returned from the scroll event was drastically different for Firefox and Chrome, a constant value is used now instead. This will normalize scroll speed across browsers.