### PR TITLE
Loaders changed to use mesh physical

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1042,7 +1042,7 @@ THREE.GLTFLoader = ( function () {
 	 */
 	function createDefaultMaterial() {
 
-		return new THREE.MeshStandardMaterial( {
+		return new THREE.MeshPhysicalMaterial( {
 			color: 0xFFFFFF,
 			emissive: 0x000000,
 			metalness: 1,
@@ -1735,7 +1735,7 @@ THREE.GLTFLoader = ( function () {
 			// Specification:
 			// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#metallic-roughness-material
 
-			materialType = THREE.MeshStandardMaterial;
+			materialType = THREE.MeshPhysicalMaterial;
 
 			var metallicRoughness = materialDef.pbrMetallicRoughness;
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -478,7 +478,7 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		}
 
-		this.materials[ materialName ] = new THREE.MeshPhongMaterial( params );
+		this.materials[ materialName ] = new THREE.MeshPhysicalMaterial( params );
 		return this.materials[ materialName ];
 
 	},


### PR DESCRIPTION
GLTF and MTL loaders now use `MeshPhysicalMaterial`.