### PR TITLE
exr error modal hotfix

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1109,7 +1109,7 @@ THREE.EXRLoader.prototype._parser = function ( buffer ) {
 
 				} else {
 
-					throw 'Only supported pixel format is HALF';
+					throw {message: 'Only supported pixel format is HALF', error: 'dataType'};
 
 				}
 


### PR DESCRIPTION
Changed one more error message from a string to an object to accommodate the front end changes to the EXR modal error message.