### PR TITLE
Offscreen Canvas Fix

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -21205,7 +21205,8 @@
 		// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
 		// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
 
-		var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
+		var useOffscreenCanvas = typeof document === 'undefined'
+			&& typeof OffscreenCanvas !== 'undefined'
 			&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
 
 		function createCanvas( width, height ) {

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -21194,7 +21194,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
 	// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
 
-	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
+	var useOffscreenCanvas = typeof document === 'undefined'
+		&& typeof OffscreenCanvas !== 'undefined'
 		&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
 
 	function createCanvas( width, height ) {

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -19,7 +19,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
 	// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
 
-	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
+	var useOffscreenCanvas = typeof document === 'undefined'
+		&& typeof OffscreenCanvas !== 'undefined'
 		&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
 
 	function createCanvas( width, height ) {


### PR DESCRIPTION
`OffscreenCanvas` was being used to resize textures. In the case the texture was size 0,0 (caused by the image not loading properly), `OffscreenCanvas` was causing WebGL to lose context. Now the document canvas is always used if it is available in order to prevent this.