### PR TITLE
CubeUVTextureSize Fix

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -17934,13 +17934,13 @@
 
 	}
 
-	function generateEnvMapCubeUVTextureSize( parameters ) {
+	function generateEnvMapCubeUVTextureSize( material ) {
 
 		var envMapCubeUVTextureSize = 1024.0;
 
-		if ( parameters.envMap && parameters.envMap.cubeUVTextureSize ) {
+		if ( material.envMap && material.envMap.cubeUVTextureSize ) {
 
-			envMapCubeUVTextureSize = parameters.envMap.cubeUVTextureSize;
+			envMapCubeUVTextureSize = material.envMap.cubeUVTextureSize;
 
 		}
 
@@ -17960,7 +17960,7 @@
 		var envMapTypeDefine = generateEnvMapTypeDefine( parameters );
 		var envMapModeDefine = generateEnvMapModeDefine( parameters );
 		var envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
-		var envMapCubeUVTextureSize = generateEnvMapCubeUVTextureSize( parameters );
+		var envMapCubeUVTextureSize = generateEnvMapCubeUVTextureSize( material );
 
 
 		var gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -17921,13 +17921,13 @@ function generateEnvMapBlendingDefine( parameters ) {
 
 }
 
-function generateEnvMapCubeUVTextureSize( parameters ) {
+function generateEnvMapCubeUVTextureSize( material ) {
 
 	var envMapCubeUVTextureSize = 1024.0;
 
-	if ( parameters.envMap && parameters.envMap.cubeUVTextureSize ) {
+	if ( material.envMap && material.envMap.cubeUVTextureSize ) {
 
-		envMapCubeUVTextureSize = parameters.envMap.cubeUVTextureSize;
+		envMapCubeUVTextureSize = material.envMap.cubeUVTextureSize;
 
 	}
 
@@ -17947,7 +17947,7 @@ function WebGLProgram( renderer, extensions, cacheKey, material, shader, paramet
 	var envMapTypeDefine = generateEnvMapTypeDefine( parameters );
 	var envMapModeDefine = generateEnvMapModeDefine( parameters );
 	var envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
-	var envMapCubeUVTextureSize = generateEnvMapCubeUVTextureSize( parameters );
+	var envMapCubeUVTextureSize = generateEnvMapCubeUVTextureSize( material );
 
 
 	var gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -382,13 +382,13 @@ function generateEnvMapBlendingDefine( parameters ) {
 
 }
 
-function generateEnvMapCubeUVTextureSize( parameters ) {
+function generateEnvMapCubeUVTextureSize( material ) {
 
 	var envMapCubeUVTextureSize = 1024.0;
 
-	if ( parameters.envMap && parameters.envMap.cubeUVTextureSize ) {
+	if ( material.envMap && material.envMap.cubeUVTextureSize ) {
 
-		envMapCubeUVTextureSize = parameters.envMap.cubeUVTextureSize
+		envMapCubeUVTextureSize = material.envMap.cubeUVTextureSize
 
 	}
 
@@ -408,7 +408,7 @@ function WebGLProgram( renderer, extensions, cacheKey, material, shader, paramet
 	var envMapTypeDefine = generateEnvMapTypeDefine( parameters );
 	var envMapModeDefine = generateEnvMapModeDefine( parameters );
 	var envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
-	var envMapCubeUVTextureSize = generateEnvMapCubeUVTextureSize( parameters );
+	var envMapCubeUVTextureSize = generateEnvMapCubeUVTextureSize( material );
 
 
 	var gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;


### PR DESCRIPTION
`CubeUVTextureSize` was not being compiled into the shader correctly, causing banding at high roughness levels.