### PR TITLE
Add scene-level envMapIntensity uniform.

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -6026,6 +6026,7 @@
 
 		this.background = null;
 		this.environment = null;
+		this.envMapIntensity = null;
 		this.fog = null;
 
 		this.overrideMaterial = null;
@@ -6052,6 +6053,7 @@
 
 			if ( source.background !== null ) { this.background = source.background.clone(); }
 			if ( source.environment !== null ) { this.environment = source.environment.clone(); }
+			if ( source.envMapIntensity !== null ) { this.envMapIntensity = source.envMapIntensity; }
 			if ( source.fog !== null ) { this.fog = source.fog.clone(); }
 
 			if ( source.overrideMaterial !== null ) { this.overrideMaterial = source.overrideMaterial.clone(); }
@@ -6069,6 +6071,7 @@
 
 			if ( this.background !== null ) { data.object.background = this.background.toJSON( meta ); }
 			if ( this.environment !== null ) { data.object.environment = this.environment.toJSON( meta ); }
+			if ( this.envMapIntensity !== null ) { data.object.envMapIntensity = this.envMapIntensity; }
 			if ( this.fog !== null ) { data.object.fog = this.fog.toJSON(); }
 
 			return data;
@@ -24657,6 +24660,7 @@
 
 			var fog = scene.fog;
 			var environment = material.isMeshStandardMaterial ? scene.environment : null;
+			var envMapIntensity = scene.envMapIntensity || material.envMapIntensity;
 
 			var materialProperties = properties.get( material );
 			var lights = currentRenderState.state.lights;
@@ -24945,7 +24949,7 @@
 
 				} else if ( material.isMeshStandardMaterial ) {
 
-					refreshUniformsCommon( m_uniforms, material, environment );
+					refreshUniformsCommon( m_uniforms, material, environment, envMapIntensity );
 
 					m_uniforms.zNear.value = camera.near;
 					m_uniforms.zFar.value = camera.far;
@@ -25058,7 +25062,7 @@
 
 		// Uniforms (refresh uniforms objects)
 
-		function refreshUniformsCommon( uniforms, material, environment ) {
+		function refreshUniformsCommon( uniforms, material, environment, envMapIntensity ) {
 
 			uniforms.opacity.value = material.opacity;
 
@@ -25097,6 +25101,7 @@
 			if ( envMap ) {
 
 				uniforms.envMap.value = envMap;
+				uniforms.envMapIntensity.value = envMapIntensity;
 
 				// don't flip CubeTexture envMaps, flip everything else:
 				//  WebGLRenderTargetCube will be flipped for backwards compatibility
@@ -25512,12 +25517,7 @@
 
 			}
 
-			if ( material.envMap || environment ) {
-
-				//uniforms.envMap.value = material.envMap; // part of uniforms common
-				uniforms.envMapIntensity.value = material.envMapIntensity;
-
-			}
+			if ( material.envMap || environment ) ;
 
 			uniforms.enableProjection.value = material.enableProjection;
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -6020,6 +6020,7 @@ function Scene() {
 
 	this.background = null;
 	this.environment = null;
+	this.envMapIntensity = null;
 	this.fog = null;
 
 	this.overrideMaterial = null;
@@ -6046,6 +6047,7 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		if ( source.background !== null ) this.background = source.background.clone();
 		if ( source.environment !== null ) this.environment = source.environment.clone();
+		if ( source.envMapIntensity !== null ) this.envMapIntensity = source.envMapIntensity;
 		if ( source.fog !== null ) this.fog = source.fog.clone();
 
 		if ( source.overrideMaterial !== null ) this.overrideMaterial = source.overrideMaterial.clone();
@@ -6063,6 +6065,7 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		if ( this.background !== null ) data.object.background = this.background.toJSON( meta );
 		if ( this.environment !== null ) data.object.environment = this.environment.toJSON( meta );
+		if ( this.envMapIntensity !== null ) data.object.envMapIntensity = this.envMapIntensity;
 		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
 
 		return data;
@@ -24838,6 +24841,7 @@ function WebGLRenderer( parameters ) {
 
 		var fog = scene.fog;
 		var environment = material.isMeshStandardMaterial ? scene.environment : null;
+		var envMapIntensity = scene.envMapIntensity || material.envMapIntensity;
 
 		var materialProperties = properties.get( material );
 		var lights = currentRenderState.state.lights;
@@ -25126,7 +25130,7 @@ function WebGLRenderer( parameters ) {
 
 			} else if ( material.isMeshStandardMaterial ) {
 
-				refreshUniformsCommon( m_uniforms, material, environment );
+				refreshUniformsCommon( m_uniforms, material, environment, envMapIntensity );
 
 				m_uniforms.zNear.value = camera.near;
 				m_uniforms.zFar.value = camera.far;
@@ -25239,7 +25243,7 @@ function WebGLRenderer( parameters ) {
 
 	// Uniforms (refresh uniforms objects)
 
-	function refreshUniformsCommon( uniforms, material, environment ) {
+	function refreshUniformsCommon( uniforms, material, environment, envMapIntensity ) {
 
 		uniforms.opacity.value = material.opacity;
 
@@ -25278,6 +25282,7 @@ function WebGLRenderer( parameters ) {
 		if ( envMap ) {
 
 			uniforms.envMap.value = envMap;
+			uniforms.envMapIntensity.value = envMapIntensity;
 
 			// don't flip CubeTexture envMaps, flip everything else:
 			//  WebGLRenderTargetCube will be flipped for backwards compatibility
@@ -25693,12 +25698,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		if ( material.envMap || environment ) {
-
-			//uniforms.envMap.value = material.envMap; // part of uniforms common
-			uniforms.envMapIntensity.value = material.envMapIntensity;
-
-		}
+		if ( material.envMap || environment ) ;
 
 		uniforms.enableProjection.value = material.enableProjection;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1624,6 +1624,7 @@ function WebGLRenderer( parameters ) {
 
 		var fog = scene.fog;
 		var environment = material.isMeshStandardMaterial ? scene.environment : null;
+		var envMapIntensity = scene.envMapIntensity || material.envMapIntensity;
 
 		var materialProperties = properties.get( material );
 		var lights = currentRenderState.state.lights;
@@ -1912,7 +1913,7 @@ function WebGLRenderer( parameters ) {
 
 			} else if ( material.isMeshStandardMaterial ) {
 
-				refreshUniformsCommon( m_uniforms, material, environment );
+				refreshUniformsCommon( m_uniforms, material, environment, envMapIntensity );
 
 				m_uniforms.zNear.value = camera.near;
 				m_uniforms.zFar.value = camera.far;
@@ -2025,7 +2026,7 @@ function WebGLRenderer( parameters ) {
 
 	// Uniforms (refresh uniforms objects)
 
-	function refreshUniformsCommon( uniforms, material, environment ) {
+	function refreshUniformsCommon( uniforms, material, environment, envMapIntensity ) {
 
 		uniforms.opacity.value = material.opacity;
 
@@ -2064,6 +2065,7 @@ function WebGLRenderer( parameters ) {
 		if ( envMap ) {
 
 			uniforms.envMap.value = envMap;
+			uniforms.envMapIntensity.value = envMapIntensity;
 
 			// don't flip CubeTexture envMaps, flip everything else:
 			//  WebGLRenderTargetCube will be flipped for backwards compatibility
@@ -2482,7 +2484,7 @@ function WebGLRenderer( parameters ) {
 		if ( material.envMap || environment ) {
 
 			//uniforms.envMap.value = material.envMap; // part of uniforms common
-			uniforms.envMapIntensity.value = material.envMapIntensity;
+			// uniforms.envMapIntensity.value = material.envMapIntensity; // part of uniforms common
 
 		}
 

--- a/src/scenes/Scene.d.ts
+++ b/src/scenes/Scene.d.ts
@@ -26,6 +26,7 @@ export class Scene extends Object3D {
 	autoUpdate: boolean;
 	background: null | Color | Texture;
 	environment: null | Texture;
+	envMapIntensity: null | number;
 
 	toJSON( meta?: any ): any;
 	dispose(): void;

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -12,6 +12,7 @@ function Scene() {
 
 	this.background = null;
 	this.environment = null;
+	this.envMapIntensity = null;
 	this.fog = null;
 
 	this.overrideMaterial = null;
@@ -38,6 +39,7 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		if ( source.background !== null ) this.background = source.background.clone();
 		if ( source.environment !== null ) this.environment = source.environment.clone();
+		if ( source.envMapIntensity !== null ) this.envMapIntensity = source.envMapIntensity;
 		if ( source.fog !== null ) this.fog = source.fog.clone();
 
 		if ( source.overrideMaterial !== null ) this.overrideMaterial = source.overrideMaterial.clone();
@@ -55,6 +57,7 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		if ( this.background !== null ) data.object.background = this.background.toJSON( meta );
 		if ( this.environment !== null ) data.object.environment = this.environment.toJSON( meta );
+		if ( this.envMapIntensity !== null ) data.object.envMapIntensity = this.envMapIntensity;
 		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
 
 		return data;


### PR DESCRIPTION
This property on scene will be used whenever it is non-null.

Otherwise, the material's envMapIntensity property will be used as
before.

It can be set using `scene.envMapIntensity` as a property. To disable it, you can write `scene.envMapIntensity = null`